### PR TITLE
Add manual stuff to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ python .\launcher.pyz g - will generate a map
 
 python .\launcher.pyz r - will run the game
 
+## Manual
+
+[Usage Manual](https://docs.google.com/document/d/1MGxvq5V9yGJbsbcBgDM26LugPbtQGlyNiaUOmjn85sc/edit?usp=sharing)
+
+Referenced Examples - https://github.com/topoftheyear/Byte-le-Game-Examples
+
 ## Previous Byte-le Competitions
 
 2018 - Dungeon Delvers - https://github.com/jghibiki/Byte-le-Royale-2018


### PR DESCRIPTION
Created a link to view the instruction manual and a link to the repo housing the examples referenced in the manual.

If the instruction manual is on an ACM drive, this can link to that instead of my personal copy if you want. Just pass a link and I'll get it changed.